### PR TITLE
Implement reactivation API

### DIFF
--- a/include/nci_adapter_impl.h
+++ b/include/nci_adapter_impl.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019 Jolla Ltd.
- * Copyright (C) 2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2020 Jolla Ltd.
+ * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -38,7 +38,7 @@
 #define NCI_PLUGIN_H
 
 #include <nfc_adapter_impl.h>
-#include <nci_types.h>
+#include <nci_plugin_types.h>
 
 G_BEGIN_DECLS
 
@@ -50,12 +50,12 @@ G_BEGIN_DECLS
 
 typedef struct nci_adapter_priv NciAdapterPriv;
 
-typedef struct nci_adapter {
+struct nci_adapter {
     NfcAdapter parent;
     NfcTarget* target;
     NciAdapterPriv* priv;
     NciCore* nci;
-} NciAdapter;
+};
 
 typedef struct nci_adapter_class {
     NfcAdapterClass parent;

--- a/include/nci_plugin_types.h
+++ b/include/nci_plugin_types.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019 Jolla Ltd.
- * Copyright (C) 2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2020 Jolla Ltd.
+ * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -40,6 +40,8 @@
 #include <nci_types.h>
 
 G_BEGIN_DECLS
+
+typedef struct nci_adapter NciAdapter;
 
 /* Logging */
 

--- a/rpm/libnciplugin.spec
+++ b/rpm/libnciplugin.spec
@@ -7,11 +7,13 @@ License: BSD
 URL: https://github.com/mer-hybris/libnciplugin
 Source: %{name}-%{version}.tar.bz2
 
+%define nfcd_version 1.0.27
+
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(libncicore)
 BuildRequires:  pkgconfig(libglibutil)
-BuildRequires: pkgconfig(nfcd-plugin) >= 1.0.25
-Requires: nfcd >= 1.0.20
+BuildRequires: pkgconfig(nfcd-plugin) >= %{nfcd_version}
+Requires: nfcd >= %{nfcd_version}
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 

--- a/src/nci_plugin_p.h
+++ b/src/nci_plugin_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019 Jolla Ltd.
- * Copyright (C) 2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2020 Jolla Ltd.
+ * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -47,18 +47,30 @@ void
     gboolean ok,
     void* user_data);
 
-G_GNUC_INTERNAL
 NfcTarget*
 nci_target_new(
-    NciCore* nci,
-    const NciIntfActivationNtf* ntf);
+    NciAdapter* adapter,
+    const NciIntfActivationNtf* ntf)
+    G_GNUC_INTERNAL;
 
-G_GNUC_INTERNAL
 guint
 nci_target_presence_check(
     NfcTarget* target,
     NciTargetPresenseCheckFunc fn,
-    void* user_data);
+    void* user_data)
+    G_GNUC_INTERNAL;
+
+gboolean
+nci_adapter_reactivate(
+    NciAdapter* adapter,
+    NfcTarget* target)
+    G_GNUC_INTERNAL;
+
+void
+nci_adapter_deactivate(
+    NciAdapter* adapter,
+    NfcTarget* target)
+    G_GNUC_INTERNAL;
 
 #endif /* NCI_PLUGIN_PRIVATE_H */
 


### PR DESCRIPTION
It's basically force-switching NCI state machine to RFST_DISCOVERY state and then expecting the same tag to show up again. Timeout is handled by NfcTarget in nfcd.