### PR TITLE
[nciplugin] Add access to poll parameters for B type tags. JB#50041

### DIFF
--- a/src/nci_adapter.c
+++ b/src/nci_adapter.c
@@ -291,6 +291,8 @@ nci_adapter_convert_poll_b(
     dest->fsc = src->fsc;
     dest->nfcid0.bytes = src->nfcid0;
     dest->nfcid0.size = sizeof(src->nfcid0);
+    dest->prot_info = src->prot_info;
+    memcpy(dest->app_data, src->app_data, sizeof(src->app_data));
     return dest;
 }
 


### PR DESCRIPTION
Expose add_data and prot_info to poll parameters for nfcd.