### PR TITLE
[nciplugin] Add ability to keep presence checking. JB#51791

### DIFF
--- a/src/nci_adapter.c
+++ b/src/nci_adapter.c
@@ -366,8 +366,11 @@ nci_adapter_presence_check_timer(
 {
     NciAdapter* self = THIS(user_data);
     NciAdapterPriv* priv = self->priv;
+    NfcTargetSequence* seq = self->target->sequence;
+    gboolean do_presence_check = !seq || (nfc_target_sequence_flags(seq)
+        & NFC_SEQUENCE_FLAG_ALLOW_PRESENCE_CHECK);
 
-    if (!priv->presence_check_id && !self->target->sequence) {
+    if (!priv->presence_check_id && do_presence_check) {
         priv->presence_check_id = nci_target_presence_check(self->target,
             nci_adapter_presence_check_done, self);
         if (!priv->presence_check_id) {

--- a/src/nci_target.c
+++ b/src/nci_target.c
@@ -253,10 +253,11 @@ nci_target_presence_check_t2(
     NciTarget* self,
     NciTargetPresenceCheck* check)
 {
+    NfcTarget* target = &self->target;
     static const guint8 cmd_data[] = { T2T_CMD_READ, 0x00 };
 
-    return nfc_target_transmit(&self->target, cmd_data, sizeof(cmd_data),
-        NULL, nci_target_presence_check_complete,
+    return nfc_target_transmit(target, cmd_data, sizeof(cmd_data),
+        target->sequence, nci_target_presence_check_complete,
         nci_target_presence_check_free1, check);
 }
 
@@ -266,8 +267,10 @@ nci_target_presence_check_t4(
     NciTarget* self,
     NciTargetPresenceCheck* check)
 {
-    return nfc_target_transmit(&self->target, NULL, 0,
-        NULL, nci_target_presence_check_complete,
+    NfcTarget* target = &self->target;
+
+    return nfc_target_transmit(target, NULL, 0,
+        target->sequence, nci_target_presence_check_complete,
         nci_target_presence_check_free1, check);
 }
 


### PR DESCRIPTION
Using `flags` field in `target` now it is possible to control
if presence checking should be keeped or not when a tag is locked
(acquired).